### PR TITLE
Remove broken links and fix Stable naming

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -9,13 +9,12 @@ Documentation for Kanidm's available in two streams, the most recent release (st
 
 For guidance on installing and using Kanidm, see the Kanidm Book. ([Latest](https://kanidm.github.io/kanidm/master/)) ([Stable](https://kanidm.github.io/kanidm/stable/)) 
 
-We also have a short developer guide. ([Latest](https://kanidm.github.io/kanidm/master/DEVELOPER_README.html)) ([Latest](https://kanidm.github.io/kanidm/stable/DEVELOPER_README.html))
+We also have a short developer guide. ([Latest](https://kanidm.github.io/kanidm/master/DEVELOPER_README.html)) ([Stable](https://kanidm.github.io/kanidm/stable/DEVELOPER_README.html))
 
 # Module documentation
 
 Below are links to rust documentation for the various Kanidm modules.
 
-| kanidm             | \[[Latest](https://kanidm.github.io/kanidm/master/rustdoc/kanidm/)\]       | \[[Stable](https://kanidm.github.io/kanidm/stable/rustdoc/kanidm/)\] |
 | kanidmd            | \[[Latest](https://kanidm.github.io/kanidm/master/rustdoc/kanidmd/)\]      | \[[Stable](https://kanidm.github.io/kanidm/stable/rustdoc/kanidmd/)\] |
 | kanidm_cli         | \[[Latest](https://kanidm.github.io/kanidm/master/rustdoc/kanidm_cli/)\]       | \[[Stable](https://kanidm.github.io/kanidm/stable/rustdoc/kanidm_cli/)\] |
 | kanidm_client      | \[[Latest](https://kanidm.github.io/kanidm/master/rustdoc/kanidm_client/)\]       | \[[Stable](https://kanidm.github.io/kanidm/stable/rustdoc/kanidm_cli/)\] |
@@ -25,5 +24,3 @@ Below are links to rust documentation for the various Kanidm modules.
 | nss_kanidm         | \[[Latest](https://kanidm.github.io/kanidm/master/rustdoc/nss_kanidm/)\] | \[[Stable](https://kanidm.github.io/kanidm/stable/rustdoc/nss_kanidm/)\] |
 | orca               | \[[Latest](https://kanidm.github.io/kanidm/master/rustdoc/orca/)\] | \[[Stable](https://kanidm.github.io/kanidm/stable/rustdoc/orca/)\] |
 | pam_kanidm         | \[[Latest](https://kanidm.github.io/kanidm/master/rustdoc/pam_kanidm/)\] | \[[Stable](https://kanidm.github.io/kanidm/stable/rustdoc/pam_kanidm/)\] |
-| score              | \[[Latest](https://kanidm.github.io/kanidm/master/rustdoc/score/)\] | \[[Stable](https://kanidm.github.io/kanidm/stable/rustdoc/score/)\] |
-


### PR DESCRIPTION
As above. Rust modules seem to no longer exist.